### PR TITLE
ModbusManagerInterface refactored to have separate result and failure callbacks

### DIFF
--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/discovery/SunspecDiscoveryProcess.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/discovery/SunspecDiscoveryProcess.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
@@ -160,10 +159,8 @@ public class SunspecDiscoveryProcess {
                 SUNSPEC_ID_SIZE, // number or words to return
                 maxTries);
 
-        comms.submitOneTimePoll(request, result -> {
-            ModbusRegisterArray registers = (@NonNull ModbusRegisterArray) result.getRegisters();
-            headerReceived(registers);
-        }, this::handleError);
+        comms.submitOneTimePoll(request, result -> result.getRegisters().ifPresent(this::headerReceived),
+                this::handleError);
     }
 
     /**
@@ -197,10 +194,8 @@ public class SunspecDiscoveryProcess {
                 MODEL_HEADER_SIZE, // number or words to return
                 maxTries);
 
-        comms.submitOneTimePoll(request, result -> {
-            ModbusRegisterArray registers = (@NonNull ModbusRegisterArray) result.getRegisters();
-            modelBlockReceived(registers);
-        }, this::handleError);
+        comms.submitOneTimePoll(request, result -> result.getRegisters().ifPresent(this::modelBlockReceived),
+                this::handleError);
     }
 
     /**
@@ -252,10 +247,8 @@ public class SunspecDiscoveryProcess {
                 block.length, // number or words to return
                 maxTries);
 
-        comms.submitOneTimePoll(request, result -> {
-            ModbusRegisterArray registers = (@NonNull ModbusRegisterArray) result.getRegisters();
-            parseCommonBlock(registers);
-        }, this::handleError);
+        comms.submitOneTimePoll(request, result -> result.getRegisters().ifPresent(this::parseCommonBlock),
+                this::handleError);
     }
 
     /**

--- a/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
+++ b/bundles/org.openhab.binding.modbus.sunspec/src/main/java/org/openhab/binding/modbus/sunspec/internal/handler/AbstractSunSpecHandler.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 
 import javax.measure.Unit;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.QuantityType;
@@ -335,8 +334,7 @@ public abstract class AbstractSunSpecHandler extends BaseThingHandler {
 
         long refreshMillis = myconfig.getRefreshMillis();
         pollTask = mycomms.registerRegularPoll(request, refreshMillis, 1000, result -> {
-            ModbusRegisterArray registers = (@NonNull ModbusRegisterArray) result.getRegisters();
-            handlePolledData(registers);
+            result.getRegisters().ifPresent(this::handlePolledData);
             if (getThing().getStatus() != ThingStatus.ONLINE) {
                 updateStatus(ThingStatus.ONLINE);
             }

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/discovery/internal/ModbusDiscoveryService.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/discovery/internal/ModbusDiscoveryService.java
@@ -15,7 +15,6 @@ package org.openhab.binding.modbus.discovery.internal;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
@@ -116,7 +115,7 @@ public class ModbusDiscoveryService extends AbstractDiscoveryService {
      * instances. They call back this method when a thing has been discovered
      */
     @Override
-    protected void thingDiscovered(@NonNull DiscoveryResult discoveryResult) {
+    protected void thingDiscovered(DiscoveryResult discoveryResult) {
         super.thingDiscovered(discoveryResult);
     }
 

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/handler/ModbusPollerThingHandler.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/handler/ModbusPollerThingHandler.java
@@ -84,7 +84,7 @@ public class ModbusPollerThingHandler extends BaseBridgeHandler {
                 }
             }
             logger.debug("Thing {} received response {}", thing.getUID(), result);
-            childCallbacks.forEach(handler -> handler.handle(result));
+            childCallbacks.forEach(handler -> handler.onReadResult(result));
             resetCommunicationError();
         }
 
@@ -115,7 +115,7 @@ public class ModbusPollerThingHandler extends BaseBridgeHandler {
             return Optional.ofNullable(this.lastResult).map(result -> result.copyIfStampAfter(oldestStamp))
                     .map(result -> {
                         logger.debug("Thing {} reusing cached data: {}", thing.getUID(), result.getValue());
-                        childCallbacks.forEach(handler -> handler.handle(result.getValue()));
+                        childCallbacks.forEach(handler -> handler.onReadResult(result.getValue()));
                         return true;
                     }).orElse(false);
         }
@@ -163,7 +163,7 @@ public class ModbusPollerThingHandler extends BaseBridgeHandler {
     private volatile @Nullable PollTask pollTask;
     private volatile @Nullable ModbusReadRequestBlueprint request;
     private volatile boolean disposed;
-    private volatile List<ModbusReadCallback> childCallbacks = new CopyOnWriteArrayList<>();
+    private volatile List<ModbusDataThingHandler> childCallbacks = new CopyOnWriteArrayList<>();
     @NonNullByDefault({})
     private ModbusCommunicationInterface comms;
 
@@ -320,15 +320,15 @@ public class ModbusPollerThingHandler extends BaseBridgeHandler {
 
     @Override
     public void childHandlerInitialized(ThingHandler childHandler, Thing childThing) {
-        if (childHandler instanceof ModbusReadCallback) {
-            this.childCallbacks.add((ModbusReadCallback) childHandler);
+        if (childHandler instanceof ModbusDataThingHandler) {
+            this.childCallbacks.add((ModbusDataThingHandler) childHandler);
         }
     }
 
     @SuppressWarnings("unlikely-arg-type")
     @Override
     public void childHandlerDisposed(ThingHandler childHandler, Thing childThing) {
-        if (childHandler instanceof ModbusReadCallback) {
+        if (childHandler instanceof ModbusDataThingHandler) {
             this.childCallbacks.remove(childHandler);
         }
     }

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/handler/ModbusPollerThingHandler.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/handler/ModbusPollerThingHandler.java
@@ -195,6 +195,12 @@ public class ModbusPollerThingHandler extends BaseBridgeHandler {
             this.result = null;
             this.failure = failure;
         }
+
+        @Override
+        public String toString() {
+            return result == null ? String.format("PollResult(result=%s)", result)
+                    : String.format("PollResult(failure=%s)", failure);
+        }
     }
 
     private final Logger logger = LoggerFactory.getLogger(ModbusPollerThingHandler.class);

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/AbstractModbusEndpointThingHandler.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/AbstractModbusEndpointThingHandler.java
@@ -102,7 +102,7 @@ public abstract class AbstractModbusEndpointThingHandler<E extends ModbusSlaveEn
                 localComms.close();
             }
         } catch (Exception e) {
-            logger.error("Error closing modbus communication interface", e);
+            logger.warn("Error closing modbus communication interface", e);
         } finally {
             comms = null;
         }

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
@@ -883,6 +883,8 @@ public class ModbusDataThingHandler extends BaseThingHandler {
         }
     }
 
+    // since lastState can be null, and "lastState == null" in conditional is not useless
+    @SuppressWarnings("null")
     private void updateExpiredChannel(long now, ChannelUID uid, State state) {
         @Nullable
         State lastState = channelLastState.get(uid);

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.items.ContactItem;
@@ -745,7 +744,7 @@ public class ModbusDataThingHandler extends BaseThingHandler {
                     getThing().getUID(), getThing().getLabel(), error.getClass().getName(), error.toString(),
                     error.getMessage(), error);
         }
-        Map<@NonNull ChannelUID, @NonNull State> states = new HashMap<>();
+        Map<ChannelUID, State> states = new HashMap<>();
         ChannelUID lastReadErrorUID = getChannelUID(ModbusBindingConstantsInternal.CHANNEL_LAST_READ_ERROR);
         if (isLinked(lastReadErrorUID)) {
             states.put(lastReadErrorUID, new DateTimeType());
@@ -781,7 +780,7 @@ public class ModbusDataThingHandler extends BaseThingHandler {
                     getThing().getUID(), getThing().getLabel(), error.getClass().getName(), error.toString(),
                     error.getMessage(), error);
         }
-        Map<@NonNull ChannelUID, @NonNull State> states = new HashMap<>();
+        Map<ChannelUID, State> states = new HashMap<>();
         ChannelUID lastWriteErrorUID = getChannelUID(ModbusBindingConstantsInternal.CHANNEL_LAST_WRITE_ERROR);
         if (isLinked(lastWriteErrorUID)) {
             states.put(lastWriteErrorUID, new DateTimeType());
@@ -827,7 +826,7 @@ public class ModbusDataThingHandler extends BaseThingHandler {
             logger.trace("No transformation available, aborting processUpdatedValue");
             return new HashMap<ChannelUID, State>();
         }
-        Map<@NonNull ChannelUID, @NonNull State> states = new HashMap<>();
+        Map<ChannelUID, State> states = new HashMap<>();
         CHANNEL_ID_TO_ACCEPTED_TYPES.keySet().stream().forEach(channelId -> {
             ChannelUID channelUID = getChannelUID(channelId);
             if (!isLinked(channelUID)) {

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
@@ -651,15 +651,8 @@ public class ModbusDataThingHandler extends BaseThingHandler {
     }
 
     public synchronized void onReadResult(AsyncModbusReadResult result) {
-        if (result.getRegisters() != null) {
-            ModbusRegisterArray registers = result.getRegisters();
-            assert registers != null;
-            onRegisters(result.getRequest(), registers);
-        } else {
-            BitArray bits = result.getBits();
-            assert bits != null;
-            onBits(result.getRequest(), bits);
-        }
+        result.getRegisters().ifPresent(registers -> onRegisters(result.getRequest(), registers));
+        result.getBits().ifPresent(registers -> onBits(result.getRequest(), registers));
     }
 
     public synchronized void handleReadError(AsyncModbusFailure<ModbusReadRequestBlueprint> failure) {

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
@@ -69,7 +69,6 @@ import org.openhab.io.transport.modbus.ModbusBitUtilities;
 import org.openhab.io.transport.modbus.ModbusCommunicationInterface;
 import org.openhab.io.transport.modbus.ModbusConstants;
 import org.openhab.io.transport.modbus.ModbusConstants.ValueType;
-import org.openhab.io.transport.modbus.ModbusReadCallback;
 import org.openhab.io.transport.modbus.ModbusReadFunctionCode;
 import org.openhab.io.transport.modbus.ModbusReadRequestBlueprint;
 import org.openhab.io.transport.modbus.ModbusRegisterArray;
@@ -96,7 +95,7 @@ import org.slf4j.LoggerFactory;
  * @author Sami Salonen - Initial contribution
  */
 @NonNullByDefault
-public class ModbusDataThingHandler extends BaseThingHandler implements ModbusReadCallback {
+public class ModbusDataThingHandler extends BaseThingHandler {
 
     private final Logger logger = LoggerFactory.getLogger(ModbusDataThingHandler.class);
 
@@ -651,8 +650,7 @@ public class ModbusDataThingHandler extends BaseThingHandler implements ModbusRe
         });
     }
 
-    @Override
-    public synchronized void handle(AsyncModbusReadResult result) {
+    public synchronized void onReadResult(AsyncModbusReadResult result) {
         if (result.getRegisters() != null) {
             ModbusRegisterArray registers = result.getRegisters();
             assert registers != null;

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusDataThingHandler.java
@@ -652,7 +652,7 @@ public class ModbusDataThingHandler extends BaseThingHandler {
 
     public synchronized void onReadResult(AsyncModbusReadResult result) {
         result.getRegisters().ifPresent(registers -> onRegisters(result.getRequest(), registers));
-        result.getBits().ifPresent(registers -> onBits(result.getRequest(), registers));
+        result.getBits().ifPresent(bits -> onBits(result.getRequest(), bits));
     }
 
     public synchronized void handleReadError(AsyncModbusFailure<ModbusReadRequestBlueprint> failure) {

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusSerialThingHandler.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusSerialThingHandler.java
@@ -84,6 +84,7 @@ public class ModbusSerialThingHandler
         }
     }
 
+    @SuppressWarnings("null") // Since endpoint in Optional.map cannot be null
     @Override
     protected String formatConflictingParameterError() {
         return String.format(

--- a/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusTcpThingHandler.java
+++ b/bundles/org.openhab.binding.modbus/src/main/java/org/openhab/binding/modbus/internal/handler/ModbusTcpThingHandler.java
@@ -61,6 +61,7 @@ public class ModbusTcpThingHandler
         poolConfiguration.setReconnectAfterMillis(config.getReconnectAfterMillis());
     }
 
+    @SuppressWarnings("null") // since Optional.map is always called with NonNull argument
     @Override
     protected String formatConflictingParameterError() {
         return String.format(
@@ -72,10 +73,11 @@ public class ModbusTcpThingHandler
 
     @Override
     public int getSlaveId() {
-        if (config == null) {
+        ModbusTcpConfiguration localConfig = config;
+        if (localConfig == null) {
             throw new IllegalStateException("Poller not configured, but slave id is queried!");
         }
-        return config.getId();
+        return localConfig.getId();
     }
 
     @Override

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/AsyncModbusFailure.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/AsyncModbusFailure.java
@@ -15,26 +15,23 @@ package org.openhab.io.transport.modbus;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * Encapsulates result of modbus write operations
+ * Encapsulates result of modbus read operations
  *
- * @author Sami Salonen - Initial contribution
+ * @author Nagy Attila Gabor - Initial contribution
  */
 @NonNullByDefault
-public class AsyncModbusWriteResult {
+public class AsyncModbusFailure<R> {
+    private R request;
 
-    private ModbusWriteRequestBlueprint request;
+    private Exception cause;
 
-    @Nullable
-    private ModbusResponse response;
-
-    public AsyncModbusWriteResult(ModbusWriteRequestBlueprint request, ModbusResponse response) {
+    public AsyncModbusFailure(R request, Exception cause) {
         Objects.requireNonNull(request, "Request must not be null!");
-        Objects.requireNonNull(response, "Response must not be null!");
+        Objects.requireNonNull(cause, "Cause must not be null!");
         this.request = request;
-        this.response = response;
+        this.cause = cause;
     }
 
     /**
@@ -42,29 +39,26 @@ public class AsyncModbusWriteResult {
      *
      * @return request object
      */
-    public ModbusWriteRequestBlueprint getRequest() {
+    public R getRequest() {
         return request;
     }
 
     /**
-     * Get response
+     * Get cause of error
      *
-     * @return response
+     * @return exception representing error
      */
-    @Nullable
-    public ModbusResponse getResponse() {
-        return response;
+    public Exception getCause() {
+        return cause;
     }
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder("AsyncModbusWriteResult(");
+        StringBuilder builder = new StringBuilder("AsyncModbusReadResult(");
         builder.append("request = ");
         builder.append(request);
-        if (response != null) {
-            builder.append(", response = ");
-            builder.append(response);
-        }
+        builder.append(", error = ");
+        builder.append(cause);
         builder.append(")");
         return builder.toString();
     }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/AsyncModbusReadResult.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/AsyncModbusReadResult.java
@@ -33,9 +33,6 @@ public class AsyncModbusReadResult {
     @Nullable
     private ModbusRegisterArray registers;
 
-    @Nullable
-    private Exception cause;
-
     public AsyncModbusReadResult(ModbusReadRequestBlueprint request, ModbusRegisterArray registers) {
         Objects.requireNonNull(request, "Request must not be null!");
         Objects.requireNonNull(registers, "Registers must not be null!");
@@ -48,22 +45,6 @@ public class AsyncModbusReadResult {
         Objects.requireNonNull(bits, "Bits must not be null!");
         this.request = request;
         this.bits = bits;
-    }
-
-    public AsyncModbusReadResult(ModbusReadRequestBlueprint request, Exception cause) {
-        Objects.requireNonNull(request, "Request must not be null!");
-        Objects.requireNonNull(cause, "Cause must not be null!");
-        this.request = request;
-        this.cause = cause;
-    }
-
-    /**
-     * Whether this response is in error, that is cause is non-null
-     *
-     * @return whether this response is in error
-     */
-    public boolean hasError() {
-        return cause != null;
     }
 
     /**
@@ -95,16 +76,6 @@ public class AsyncModbusReadResult {
         return registers;
     }
 
-    /**
-     * Get cause of error
-     *
-     * @return exception representing error
-     */
-    @Nullable
-    public Exception getCause() {
-        return cause;
-    }
-
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder("AsyncModbusReadResult(");
@@ -116,9 +87,6 @@ public class AsyncModbusReadResult {
         } else if (registers != null) {
             builder.append(", registers = ");
             builder.append(registers);
-        } else {
-            builder.append(", error = ");
-            builder.append(cause);
         }
         builder.append(")");
         return builder.toString();

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/AsyncModbusReadResult.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/AsyncModbusReadResult.java
@@ -13,9 +13,9 @@
 package org.openhab.io.transport.modbus;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Encapsulates result of modbus read operations
@@ -27,24 +27,24 @@ public class AsyncModbusReadResult {
 
     private ModbusReadRequestBlueprint request;
 
-    @Nullable
-    private BitArray bits;
+    private final Optional<BitArray> bits;
 
-    @Nullable
-    private ModbusRegisterArray registers;
+    private final Optional<ModbusRegisterArray> registers;
 
     public AsyncModbusReadResult(ModbusReadRequestBlueprint request, ModbusRegisterArray registers) {
         Objects.requireNonNull(request, "Request must not be null!");
         Objects.requireNonNull(registers, "Registers must not be null!");
         this.request = request;
-        this.registers = registers;
+        this.registers = Optional.of(registers);
+        this.bits = Optional.empty();
     }
 
     public AsyncModbusReadResult(ModbusReadRequestBlueprint request, BitArray bits) {
         Objects.requireNonNull(request, "Request must not be null!");
         Objects.requireNonNull(bits, "Bits must not be null!");
         this.request = request;
-        this.bits = bits;
+        this.registers = Optional.empty();
+        this.bits = Optional.of(bits);
     }
 
     /**
@@ -61,8 +61,7 @@ public class AsyncModbusReadResult {
      *
      * @return bit data
      */
-    @Nullable
-    public BitArray getBits() {
+    public Optional<BitArray> getBits() {
         return bits;
     }
 
@@ -71,8 +70,7 @@ public class AsyncModbusReadResult {
      *
      * @return register data
      */
-    @Nullable
-    public ModbusRegisterArray getRegisters() {
+    public Optional<ModbusRegisterArray> getRegisters() {
         return registers;
     }
 
@@ -81,13 +79,14 @@ public class AsyncModbusReadResult {
         StringBuilder builder = new StringBuilder("AsyncModbusReadResult(");
         builder.append("request = ");
         builder.append(request);
-        if (bits != null) {
+        bits.ifPresent(bits -> {
             builder.append(", bits = ");
             builder.append(bits);
-        } else if (registers != null) {
+        });
+        registers.ifPresent(registers -> {
             builder.append(", registers = ");
             builder.append(registers);
-        }
+        });
         builder.append(")");
         return builder.toString();
     }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.io.transport.modbus;
 
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -91,6 +92,6 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      * @return future representing the task
      * @throws IllegalStateException when this communication has been closed already
      */
-    public ScheduledFuture<?> submitOneTimeWrite(ModbusWriteRequestBlueprint request,
-            ModbusWriteCallback resultCallback, ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback);
+    public Future<?> submitOneTimeWrite(ModbusWriteRequestBlueprint request, ModbusWriteCallback resultCallback,
+            ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback);
 }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
@@ -13,7 +13,6 @@
 package org.openhab.io.transport.modbus;
 
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledFuture;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.io.transport.modbus.endpoint.ModbusSlaveEndpoint;
@@ -51,7 +50,7 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      * @return future representing the polled task
      * @throws IllegalStateException when this communication has been closed already
      */
-    public ScheduledFuture<?> submitOneTimePoll(ModbusReadRequestBlueprint request, ModbusReadCallback resultCallback,
+    public Future<?> submitOneTimePoll(ModbusReadRequestBlueprint request, ModbusReadCallback resultCallback,
             ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback);
 
     /**

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
@@ -46,11 +46,13 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      * background.
      *
      * @param request request to send
-     * @param callback callback to call with errors and data
+     * @param callback callback to call with data
+     * @param callback callback to call in case of failure
      * @return future representing the polled task
      * @throws IllegalStateException when this communication has been closed already
      */
-    public ScheduledFuture<?> submitOneTimePoll(ModbusReadRequestBlueprint request, ModbusReadCallback callback);
+    public ScheduledFuture<?> submitOneTimePoll(ModbusReadRequestBlueprint request, ModbusReadCallback resultCallback,
+            @Nullable ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback);
 
     /**
      * Register regularly polled task. The method returns immediately, and the execution of the poll task will happen in
@@ -61,12 +63,14 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      * @param request request to send
      * @param pollPeriodMillis poll interval, in milliseconds
      * @param initialDelayMillis initial delay before starting polling, in milliseconds
-     * @param callback callback to call with errors and data
+     * @param callback callback to call with data
+     * @param callback callback to call in case of failure
      * @return poll task representing the regular poll
      * @throws IllegalStateException when this communication has been closed already
      */
     public PollTask registerRegularPoll(ModbusReadRequestBlueprint request, long pollPeriodMillis,
-            long initialDelayMillis, ModbusReadCallback callback);
+            long initialDelayMillis, ModbusReadCallback resultCallback,
+            @Nullable ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback);
 
     /**
      * Unregister regularly polled task
@@ -83,10 +87,12 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      * background.
      *
      * @param request request to send
-     * @param callback callback to call with errors and response
+     * @param callback callback to call with response
+     * @param callback callback to call in case of failure
      * @return future representing the task
      * @throws IllegalStateException when this communication has been closed already
      */
     public ScheduledFuture<?> submitOneTimeWrite(ModbusWriteRequestBlueprint request,
-            @Nullable ModbusWriteCallback callback);
+            @Nullable ModbusWriteCallback resultCallback,
+            @Nullable ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback);
 }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
@@ -15,7 +15,6 @@ package org.openhab.io.transport.modbus;
 import java.util.concurrent.ScheduledFuture;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.io.transport.modbus.endpoint.ModbusSlaveEndpoint;
 
 /**
@@ -52,7 +51,7 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      * @throws IllegalStateException when this communication has been closed already
      */
     public ScheduledFuture<?> submitOneTimePoll(ModbusReadRequestBlueprint request, ModbusReadCallback resultCallback,
-            @Nullable ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback);
+            ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback);
 
     /**
      * Register regularly polled task. The method returns immediately, and the execution of the poll task will happen in
@@ -70,7 +69,7 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      */
     public PollTask registerRegularPoll(ModbusReadRequestBlueprint request, long pollPeriodMillis,
             long initialDelayMillis, ModbusReadCallback resultCallback,
-            @Nullable ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback);
+            ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback);
 
     /**
      * Unregister regularly polled task
@@ -93,6 +92,5 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      * @throws IllegalStateException when this communication has been closed already
      */
     public ScheduledFuture<?> submitOneTimeWrite(ModbusWriteRequestBlueprint request,
-            @Nullable ModbusWriteCallback resultCallback,
-            @Nullable ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback);
+            ModbusWriteCallback resultCallback, ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback);
 }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusCommunicationInterface.java
@@ -50,8 +50,7 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      * @return future representing the polled task
      * @throws IllegalStateException when this communication has been closed already
      */
-    public ScheduledFuture<?> submitOneTimePoll(ModbusReadRequestBlueprint request,
-            @Nullable ModbusReadCallback callback);
+    public ScheduledFuture<?> submitOneTimePoll(ModbusReadRequestBlueprint request, ModbusReadCallback callback);
 
     /**
      * Register regularly polled task. The method returns immediately, and the execution of the poll task will happen in
@@ -67,7 +66,7 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      * @throws IllegalStateException when this communication has been closed already
      */
     public PollTask registerRegularPoll(ModbusReadRequestBlueprint request, long pollPeriodMillis,
-            long initialDelayMillis, @Nullable ModbusReadCallback callback);
+            long initialDelayMillis, ModbusReadCallback callback);
 
     /**
      * Unregister regularly polled task

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusFailureCallback.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusFailureCallback.java
@@ -15,10 +15,16 @@ package org.openhab.io.transport.modbus;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * Base interface for callbacks used in Modbus
+ * Callback used to report failure in Modbus
  *
- * @author Sami Salonen - Initial contribution
+ * @author Nagy Attila Gabor - Initial contribution
  */
 @NonNullByDefault
-public interface ModbusCallback {
+public interface ModbusFailureCallback<R> {
+    /**
+     * Callback handling response with error
+     *
+     * @param asyncModbusFailure details of the failure
+     */
+    void handle(AsyncModbusFailure<R> failure);
 }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusReadCallback.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusReadCallback.java
@@ -21,10 +21,10 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @FunctionalInterface
 @NonNullByDefault
-public interface ModbusReadCallback extends ModbusCallback {
+public interface ModbusReadCallback extends ModbusResultCallback {
 
     /**
-     * Callback handling response data and errors
+     * Callback handling response data
      *
      * @param result result of the read operation
      */

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusResultCallback.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusResultCallback.java
@@ -15,18 +15,10 @@ package org.openhab.io.transport.modbus;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * Poll task represents Modbus write request
- *
- * Unlike {@link PollTask}, this does not have to be hashable.
+ * Base interface for callbacks used in Modbus
  *
  * @author Sami Salonen - Initial contribution
- *
  */
 @NonNullByDefault
-public interface WriteTask extends
-        TaskWithEndpoint<ModbusWriteRequestBlueprint, ModbusWriteCallback, ModbusFailureCallback<ModbusWriteRequestBlueprint>> {
-    @Override
-    default int getMaxTries() {
-        return getRequest().getMaxTries();
-    }
+public interface ModbusResultCallback {
 }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusWriteCallback.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/ModbusWriteCallback.java
@@ -21,10 +21,10 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @FunctionalInterface
 @NonNullByDefault
-public interface ModbusWriteCallback extends ModbusCallback {
+public interface ModbusWriteCallback extends ModbusResultCallback {
 
     /**
-     * Callback handling response data and errors
+     * Callback handling response data
      *
      * @param asyncModbusWriteResult result of the write operation
      */

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/PollTask.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/PollTask.java
@@ -25,7 +25,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * @see ModbusManager.registerRegularPoll
  */
 @NonNullByDefault
-public interface PollTask extends TaskWithEndpoint<ModbusReadRequestBlueprint, ModbusReadCallback> {
+public interface PollTask extends
+        TaskWithEndpoint<ModbusReadRequestBlueprint, ModbusReadCallback, ModbusFailureCallback<ModbusReadRequestBlueprint>> {
     @Override
     default int getMaxTries() {
         return getRequest().getMaxTries();

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/TaskWithEndpoint.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/TaskWithEndpoint.java
@@ -25,7 +25,7 @@ import org.openhab.io.transport.modbus.endpoint.ModbusSlaveEndpoint;
  * @param <C> callback type
  */
 @NonNullByDefault
-public interface TaskWithEndpoint<R, C extends ModbusCallback> {
+public interface TaskWithEndpoint<R, C extends ModbusResultCallback, F extends ModbusFailureCallback<R>> {
     /**
      * Gets endpoint associated with this task
      *
@@ -41,12 +41,20 @@ public interface TaskWithEndpoint<R, C extends ModbusCallback> {
     R getRequest();
 
     /**
-     * Gets callback associated with this task, will be called with response
+     * Gets the result callback associated with this task, will be called with response
      *
      * @return
      */
     @Nullable
-    C getCallback();
+    C getResultCallback();
+
+    /**
+     * Gets the failure callback associated with this task, will be called in case of an error
+     *
+     * @return
+     */
+    @Nullable
+    F getFailureCallback();
 
     int getMaxTries();
 }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/TaskWithEndpoint.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/TaskWithEndpoint.java
@@ -13,7 +13,6 @@
 package org.openhab.io.transport.modbus;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.io.transport.modbus.endpoint.ModbusSlaveEndpoint;
 
 /**
@@ -45,7 +44,6 @@ public interface TaskWithEndpoint<R, C extends ModbusResultCallback, F extends M
      *
      * @return
      */
-    @Nullable
     C getResultCallback();
 
     /**
@@ -53,7 +51,6 @@ public interface TaskWithEndpoint<R, C extends ModbusResultCallback, F extends M
      *
      * @return
      */
-    @Nullable
     F getFailureCallback();
 
     int getMaxTries();

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/BasicPollTask.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/BasicPollTask.java
@@ -44,14 +44,10 @@ public class BasicPollTask implements PollTask {
 
     private ModbusSlaveEndpoint endpoint;
     private ModbusReadRequestBlueprint request;
-    private @Nullable ModbusReadCallback callback;
-
-    public BasicPollTask(ModbusSlaveEndpoint endpoint, ModbusReadRequestBlueprint request) {
-        this(endpoint, request, null);
-    }
+    private ModbusReadCallback callback;
 
     public BasicPollTask(ModbusSlaveEndpoint endpoint, ModbusReadRequestBlueprint request,
-            @Nullable ModbusReadCallback callback) {
+            ModbusReadCallback callback) {
         this.endpoint = endpoint;
         this.request = request;
         this.callback = callback;

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/BasicPollTask.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/BasicPollTask.java
@@ -46,12 +46,10 @@ public class BasicPollTask implements PollTask {
     private ModbusSlaveEndpoint endpoint;
     private ModbusReadRequestBlueprint request;
     private ModbusReadCallback resultCallback;
-    @Nullable
     private ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback;
 
     public BasicPollTask(ModbusSlaveEndpoint endpoint, ModbusReadRequestBlueprint request,
-            ModbusReadCallback resultCallback,
-            @Nullable ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback) {
+            ModbusReadCallback resultCallback, ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback) {
         this.endpoint = endpoint;
         this.request = request;
         this.resultCallback = resultCallback;
@@ -69,12 +67,12 @@ public class BasicPollTask implements PollTask {
     }
 
     @Override
-    public @Nullable ModbusReadCallback getResultCallback() {
+    public ModbusReadCallback getResultCallback() {
         return resultCallback;
     }
 
     @Override
-    public @Nullable ModbusFailureCallback<ModbusReadRequestBlueprint> getFailureCallback() {
+    public ModbusFailureCallback<ModbusReadRequestBlueprint> getFailureCallback() {
         return failureCallback;
     }
 

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/BasicPollTask.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/BasicPollTask.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang.builder.StandardToStringStyle;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.io.transport.modbus.ModbusFailureCallback;
 import org.openhab.io.transport.modbus.ModbusReadCallback;
 import org.openhab.io.transport.modbus.ModbusReadRequestBlueprint;
 import org.openhab.io.transport.modbus.PollTask;
@@ -44,13 +45,17 @@ public class BasicPollTask implements PollTask {
 
     private ModbusSlaveEndpoint endpoint;
     private ModbusReadRequestBlueprint request;
-    private ModbusReadCallback callback;
+    private ModbusReadCallback resultCallback;
+    @Nullable
+    private ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback;
 
     public BasicPollTask(ModbusSlaveEndpoint endpoint, ModbusReadRequestBlueprint request,
-            ModbusReadCallback callback) {
+            ModbusReadCallback resultCallback,
+            @Nullable ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback) {
         this.endpoint = endpoint;
         this.request = request;
-        this.callback = callback;
+        this.resultCallback = resultCallback;
+        this.failureCallback = failureCallback;
     }
 
     @Override
@@ -64,19 +69,26 @@ public class BasicPollTask implements PollTask {
     }
 
     @Override
-    public @Nullable ModbusReadCallback getCallback() {
-        return callback;
+    public @Nullable ModbusReadCallback getResultCallback() {
+        return resultCallback;
+    }
+
+    @Override
+    public @Nullable ModbusFailureCallback<ModbusReadRequestBlueprint> getFailureCallback() {
+        return failureCallback;
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(69, 5).append(request).append(getEndpoint()).append(getCallback()).toHashCode();
+        return new HashCodeBuilder(69, 5).append(request).append(getEndpoint()).append(getResultCallback())
+                .append(getFailureCallback()).toHashCode();
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, toStringStyle).append("request", request).append("endpoint", endpoint)
-                .append("callback", getCallback()).toString();
+                .append("resultCallback", getResultCallback()).append("failureCallback", getFailureCallback())
+                .toString();
     }
 
     @Override
@@ -92,6 +104,7 @@ public class BasicPollTask implements PollTask {
         }
         BasicPollTask rhs = (BasicPollTask) obj;
         return new EqualsBuilder().append(request, rhs.request).append(endpoint, rhs.endpoint)
-                .append(getCallback(), rhs.getCallback()).isEquals();
+                .append(getResultCallback(), rhs.getResultCallback())
+                .append(getFailureCallback(), rhs.getFailureCallback()).isEquals();
     }
 }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/BasicWriteTask.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/BasicWriteTask.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang.builder.StandardToStringStyle;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.io.transport.modbus.ModbusFailureCallback;
 import org.openhab.io.transport.modbus.ModbusWriteCallback;
 import org.openhab.io.transport.modbus.ModbusWriteRequestBlueprint;
 import org.openhab.io.transport.modbus.WriteTask;
@@ -37,14 +38,17 @@ public class BasicWriteTask implements WriteTask {
 
     private ModbusSlaveEndpoint endpoint;
     private ModbusWriteRequestBlueprint request;
-    private @Nullable ModbusWriteCallback callback;
+    private @Nullable ModbusWriteCallback resultCallback;
+    private @Nullable ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback;
 
     public BasicWriteTask(ModbusSlaveEndpoint endpoint, ModbusWriteRequestBlueprint request,
-            @Nullable ModbusWriteCallback callback) {
+            @Nullable ModbusWriteCallback resultCallback,
+            @Nullable ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback) {
         super();
         this.endpoint = endpoint;
         this.request = request;
-        this.callback = callback;
+        this.resultCallback = resultCallback;
+        this.failureCallback = failureCallback;
     }
 
     @Override
@@ -58,13 +62,18 @@ public class BasicWriteTask implements WriteTask {
     }
 
     @Override
-    public @Nullable ModbusWriteCallback getCallback() {
-        return callback;
+    public @Nullable ModbusWriteCallback getResultCallback() {
+        return resultCallback;
+    }
+
+    @Override
+    public @Nullable ModbusFailureCallback<ModbusWriteRequestBlueprint> getFailureCallback() {
+        return failureCallback;
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, TO_STRING_STYLE).append("request", request).append("endpoint", endpoint)
-                .append("callback", callback).toString();
+                .append("resultCallback", resultCallback).append("failureCallback", failureCallback).toString();
     }
 }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/BasicWriteTask.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/BasicWriteTask.java
@@ -15,7 +15,6 @@ package org.openhab.io.transport.modbus.internal;
 import org.apache.commons.lang.builder.StandardToStringStyle;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.io.transport.modbus.ModbusFailureCallback;
 import org.openhab.io.transport.modbus.ModbusWriteCallback;
 import org.openhab.io.transport.modbus.ModbusWriteRequestBlueprint;
@@ -38,12 +37,11 @@ public class BasicWriteTask implements WriteTask {
 
     private ModbusSlaveEndpoint endpoint;
     private ModbusWriteRequestBlueprint request;
-    private @Nullable ModbusWriteCallback resultCallback;
-    private @Nullable ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback;
+    private ModbusWriteCallback resultCallback;
+    private ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback;
 
     public BasicWriteTask(ModbusSlaveEndpoint endpoint, ModbusWriteRequestBlueprint request,
-            @Nullable ModbusWriteCallback resultCallback,
-            @Nullable ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback) {
+            ModbusWriteCallback resultCallback, ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback) {
         super();
         this.endpoint = endpoint;
         this.request = request;
@@ -62,12 +60,12 @@ public class BasicWriteTask implements WriteTask {
     }
 
     @Override
-    public @Nullable ModbusWriteCallback getResultCallback() {
+    public ModbusWriteCallback getResultCallback() {
         return resultCallback;
     }
 
     @Override
-    public @Nullable ModbusFailureCallback<ModbusWriteRequestBlueprint> getFailureCallback() {
+    public ModbusFailureCallback<ModbusWriteRequestBlueprint> getFailureCallback() {
         return failureCallback;
     }
 

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -833,8 +834,7 @@ public class ModbusManagerImpl implements ModbusManager {
         }
 
         @Override
-        public ScheduledFuture<?> submitOneTimeWrite(ModbusWriteRequestBlueprint request,
-                ModbusWriteCallback resultCallback,
+        public Future<?> submitOneTimeWrite(ModbusWriteRequestBlueprint request, ModbusWriteCallback resultCallback,
                 ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback) {
             if (closed) {
                 throw new IllegalStateException("Communication interface is closed already!");
@@ -844,12 +844,12 @@ public class ModbusManagerImpl implements ModbusManager {
             WriteTask task = new BasicWriteTask(endpoint, request, resultCallback, failureCallback);
             long scheduleTime = System.currentTimeMillis();
             logger.debug("Scheduling one-off write task {}", task);
-            ScheduledFuture<?> future = localScheduledThreadPoolExecutor.schedule(() -> {
+            Future<?> future = localScheduledThreadPoolExecutor.submit(() -> {
                 long millisInThreadPoolWaiting = System.currentTimeMillis() - scheduleTime;
                 logger.debug("Will now execute one-off write task {}, waited in thread pool for {}", task,
                         millisInThreadPoolWaiting);
                 executeOperation(task, true, writeOperation);
-            }, 0L, TimeUnit.MILLISECONDS);
+            });
             return future;
         }
 

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -211,10 +211,8 @@ public class ModbusManagerImpl implements ModbusManager {
             checkTransactionId(response, libRequest, operationId);
             checkFunctionCode(response, libRequest, operationId);
             checkResponseSize(response, request, operationId);
-            if (callback != null) {
-                timer.callback.timeRunnable(
-                        () -> ModbusLibraryWrapper.invokeCallbackWithResponse(request, callback, response));
-            }
+            timer.callback
+                    .timeRunnable(() -> ModbusLibraryWrapper.invokeCallbackWithResponse(request, callback, response));
         }
     }
 
@@ -250,10 +248,8 @@ public class ModbusManagerImpl implements ModbusManager {
                     response.getFunctionCode(), response.getTransactionID(), response.getHexMessage(), operationId);
             checkTransactionId(response, libRequest, operationId);
             checkFunctionCode(response, libRequest, operationId);
-            if (callback != null) {
-                timer.callback.timeRunnable(
-                        () -> invokeCallbackWithResponse(request, callback, new ModbusResponseImpl(response)));
-            }
+            timer.callback.timeRunnable(
+                    () -> invokeCallbackWithResponse(request, callback, new ModbusResponseImpl(response)));
         }
     }
 
@@ -478,10 +474,8 @@ public class ModbusManagerImpl implements ModbusManager {
         if (!connection.isPresent()) {
             logger.warn("Could not connect to endpoint {} -- aborting request {} [operation ID {}]", endpoint, request,
                     operationId);
-            if (failureCallback != null) {
-                timer.callback.timeRunnable(() -> invokeCallbackWithError(request, failureCallback,
-                        new ModbusConnectionException(endpoint)));
-            }
+            timer.callback.timeRunnable(
+                    () -> invokeCallbackWithError(request, failureCallback, new ModbusConnectionException(endpoint)));
         }
         return connection;
     }
@@ -532,7 +526,7 @@ public class ModbusManagerImpl implements ModbusManager {
      * @param operation
      */
     private <R, C extends ModbusResultCallback, F extends ModbusFailureCallback<R>, T extends TaskWithEndpoint<R, C, F>> void executeOperation(
-            @NonNull T task, boolean oneOffTask, ModbusOperation<T> operation) {
+            T task, boolean oneOffTask, ModbusOperation<T> operation) {
         AggregateStopWatch timer = new AggregateStopWatch();
         timer.total.resume();
         String operationId = timer.operationId;
@@ -547,10 +541,10 @@ public class ModbusManagerImpl implements ModbusManager {
         logTaskQueueInfo();
         R request = task.getRequest();
         ModbusSlaveEndpoint endpoint = task.getEndpoint();
-        @Nullable
         F failureCallback = task.getFailureCallback();
         int maxTries = task.getMaxTries();
         AtomicReference<@Nullable Exception> lastError = new AtomicReference<>();
+        @SuppressWarnings("null") // since cfg in lambda cannot be really null
         long retryDelay = Optional.ofNullable(connectionFactory.getEndpointPoolConfiguration(endpoint))
                 .map(cfg -> cfg.getInterTransactionDelayMillis()).orElse(0L);
 
@@ -709,11 +703,9 @@ public class ModbusManagerImpl implements ModbusManager {
             Exception exception = lastError.get();
             if (exception != null) {
                 // All retries failed with some error
-                if (failureCallback != null) {
-                    timer.callback.timeRunnable(() -> {
-                        invokeCallbackWithError(request, failureCallback, exception);
-                    });
-                }
+                timer.callback.timeRunnable(() -> {
+                    invokeCallbackWithError(request, failureCallback, exception);
+                });
             }
         } catch (PollTaskUnregistered e) {
             logger.warn("Poll task was unregistered -- not executing/proceeding with the poll: {} [operation ID {}]",

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -756,8 +756,7 @@ public class ModbusManagerImpl implements ModbusManager {
         }
 
         @Override
-        public ScheduledFuture<?> submitOneTimePoll(ModbusReadRequestBlueprint request,
-                @Nullable ModbusReadCallback callback) {
+        public ScheduledFuture<?> submitOneTimePoll(ModbusReadRequestBlueprint request, ModbusReadCallback callback) {
             if (closed) {
                 throw new IllegalStateException("Communication interface is closed already!");
             }
@@ -777,7 +776,7 @@ public class ModbusManagerImpl implements ModbusManager {
 
         @Override
         public PollTask registerRegularPoll(ModbusReadRequestBlueprint request, long pollPeriodMillis,
-                long initialDelayMillis, @Nullable ModbusReadCallback callback) {
+                long initialDelayMillis, ModbusReadCallback callback) {
             synchronized (ModbusManagerImpl.this) {
                 if (closed) {
                     throw new IllegalStateException("Communication interface is closed already!");

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -750,8 +750,7 @@ public class ModbusManagerImpl implements ModbusManager {
 
         @Override
         public ScheduledFuture<?> submitOneTimePoll(ModbusReadRequestBlueprint request,
-                ModbusReadCallback resultCallback,
-                @Nullable ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback) {
+                ModbusReadCallback resultCallback, ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback) {
             if (closed) {
                 throw new IllegalStateException("Communication interface is closed already!");
             }
@@ -772,7 +771,7 @@ public class ModbusManagerImpl implements ModbusManager {
         @Override
         public PollTask registerRegularPoll(ModbusReadRequestBlueprint request, long pollPeriodMillis,
                 long initialDelayMillis, ModbusReadCallback resultCallback,
-                @Nullable ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback) {
+                ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback) {
             synchronized (ModbusManagerImpl.this) {
                 if (closed) {
                     throw new IllegalStateException("Communication interface is closed already!");
@@ -843,8 +842,8 @@ public class ModbusManagerImpl implements ModbusManager {
 
         @Override
         public ScheduledFuture<?> submitOneTimeWrite(ModbusWriteRequestBlueprint request,
-                @Nullable ModbusWriteCallback resultCallback,
-                @Nullable ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback) {
+                ModbusWriteCallback resultCallback,
+                ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback) {
             if (closed) {
                 throw new IllegalStateException("Communication interface is closed already!");
             }

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -742,8 +742,8 @@ public class ModbusManagerImpl implements ModbusManager {
         }
 
         @Override
-        public ScheduledFuture<?> submitOneTimePoll(ModbusReadRequestBlueprint request,
-                ModbusReadCallback resultCallback, ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback) {
+        public Future<?> submitOneTimePoll(ModbusReadRequestBlueprint request, ModbusReadCallback resultCallback,
+                ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback) {
             if (closed) {
                 throw new IllegalStateException("Communication interface is closed already!");
             }
@@ -752,12 +752,12 @@ public class ModbusManagerImpl implements ModbusManager {
             long scheduleTime = System.currentTimeMillis();
             BasicPollTask task = new BasicPollTask(endpoint, request, resultCallback, failureCallback);
             logger.debug("Scheduling one-off poll task {}", task);
-            ScheduledFuture<?> future = executor.schedule(() -> {
+            Future<?> future = executor.submit(() -> {
                 long millisInThreadPoolWaiting = System.currentTimeMillis() - scheduleTime;
                 logger.debug("Will now execute one-off poll task {}, waited in thread pool for {}", task,
                         millisInThreadPoolWaiting);
                 executeOperation(task, true, pollOperation);
-            }, 0L, TimeUnit.MILLISECONDS);
+            });
             return future;
         }
 

--- a/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.io.transport.modbus/src/main/java/org/openhab/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -826,9 +826,9 @@ public class ModbusManagerImpl implements ModbusManager {
                     logger.warn("Caller tried to unregister nonexisting poll task {}", task);
                     return false;
                 }
-                logger.info("Unregistering regular poll task {} (interrupting if necessary)", task);
+                logger.debug("Unregistering regular poll task {} (interrupting if necessary)", task);
                 future.cancel(true);
-                logger.info("Poll task {} canceled", task);
+                logger.debug("Poll task {} canceled", task);
                 return true;
             }
         }

--- a/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/SmokeTest.java
+++ b/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/SmokeTest.java
@@ -604,7 +604,6 @@ public class SmokeTest extends IntegrationTestSupport {
             long end = System.currentTimeMillis();
             assertPollDetails(unexpectedCount, dataReceived, start, end, 145, 500);
         }
-
     }
 
     /**

--- a/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/SmokeTest.java
+++ b/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/SmokeTest.java
@@ -150,13 +150,12 @@ public class SmokeTest extends IntegrationTestSupport {
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.submitOneTimePoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 0, 5, 1), result -> {
-                        if (result.getRegisters() != null) {
-                            assert !result.hasError();
-                            okCount.incrementAndGet();
-                        } else {
-                            errorCount.incrementAndGet();
-                            lastError.set(result.getCause());
-                        }
+                        assert result.getRegisters() != null;
+                        okCount.incrementAndGet();
+                        callbackCalled.countDown();
+                    }, failure -> {
+                        errorCount.incrementAndGet();
+                        lastError.set(failure.getCause());
                         callbackCalled.countDown();
                     });
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
@@ -188,14 +187,12 @@ public class SmokeTest extends IntegrationTestSupport {
                 configuration)) {
             comms.submitOneTimePoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 0, 5, 1), result -> {
-                        if (result.getRegisters() != null) {
-                            assert !result.hasError();
-                            okCount.incrementAndGet();
-                        } else {
-                            assert result.hasError();
-                            errorCount.incrementAndGet();
-                            lastError.set(result.getCause());
-                        }
+                        assert result.getRegisters() != null;
+                        okCount.incrementAndGet();
+                        callbackCalled.countDown();
+                    }, failure -> {
+                        errorCount.incrementAndGet();
+                        lastError.set(failure.getCause());
                         callbackCalled.countDown();
                     });
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
@@ -224,14 +221,12 @@ public class SmokeTest extends IntegrationTestSupport {
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.submitOneTimePoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 0, 5, 1), result -> {
-                        if (result.getRegisters() != null) {
-                            assert !result.hasError();
-                            okCount.incrementAndGet();
-                        } else {
-                            assert result.hasError();
-                            errorCount.incrementAndGet();
-                            lastError.set(result.getCause());
-                        }
+                        assert result.getRegisters() != null;
+                        okCount.incrementAndGet();
+                        callbackCalled.countDown();
+                    }, failure -> {
+                        errorCount.incrementAndGet();
+                        lastError.set(failure.getCause());
                         callbackCalled.countDown();
                     });
             assertTrue(callbackCalled.await(15, TimeUnit.SECONDS));
@@ -261,6 +256,9 @@ public class SmokeTest extends IntegrationTestSupport {
                         } else {
                             unexpectedCount.incrementAndGet();
                         }
+                        callbackCalled.countDown();
+                    }, failure -> {
+                        unexpectedCount.incrementAndGet();
                         callbackCalled.countDown();
                     });
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
@@ -352,10 +350,14 @@ public class SmokeTest extends IntegrationTestSupport {
             comms.submitOneTimePoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 1, 15, 1), result -> {
                         if (result.getRegisters() != null) {
+                            assert result.getRegisters() != null;
                             lastData.set(result.getRegisters());
                         } else {
                             unexpectedCount.incrementAndGet();
                         }
+                        callbackCalled.countDown();
+                    }, failure -> {
+                        unexpectedCount.incrementAndGet();
                         callbackCalled.countDown();
                     });
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
@@ -383,10 +385,14 @@ public class SmokeTest extends IntegrationTestSupport {
             comms.submitOneTimePoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_INPUT_REGISTERS, 1, 15, 1), result -> {
                         if (result.getRegisters() != null) {
+                            assert result.getRegisters() != null;
                             lastData.set(result.getRegisters());
                         } else {
                             unexpectedCount.incrementAndGet();
                         }
+                        callbackCalled.countDown();
+                    }, failure -> {
+                        unexpectedCount.incrementAndGet();
                         callbackCalled.countDown();
                     });
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
@@ -414,11 +420,9 @@ public class SmokeTest extends IntegrationTestSupport {
         BitArray bits = new BitArray(true, true, false, false, true, true);
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.submitOneTimeWrite(new ModbusWriteCoilRequestBlueprint(SLAVE_UNIT_ID, 3, bits, true, 1), result -> {
-                if (result.hasError()) {
-                    unexpectedCount.incrementAndGet();
-                } else {
-                    lastData.set(result.getResponse());
-                }
+                lastData.set(result.getResponse());
+            }, failure -> {
+                unexpectedCount.incrementAndGet();
             });
             waitForAssert(() -> {
                 assertThat(unexpectedCount.get(), is(equalTo(0)));
@@ -457,11 +461,10 @@ public class SmokeTest extends IntegrationTestSupport {
         BitArray bits = new BitArray(500);
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.submitOneTimeWrite(new ModbusWriteCoilRequestBlueprint(SLAVE_UNIT_ID, 3, bits, true, 1), result -> {
-                if (result.hasError()) {
-                    lastError.set(result.getCause());
-                } else {
-                    unexpectedCount.incrementAndGet();
-                }
+                unexpectedCount.incrementAndGet();
+                callbackCalled.countDown();
+            }, failure -> {
+                lastError.set(failure.getCause());
                 callbackCalled.countDown();
             });
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
@@ -496,11 +499,10 @@ public class SmokeTest extends IntegrationTestSupport {
         BitArray bits = new BitArray(true);
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.submitOneTimeWrite(new ModbusWriteCoilRequestBlueprint(SLAVE_UNIT_ID, 3, bits, false, 1), result -> {
-                if (result.hasError()) {
-                    unexpectedCount.incrementAndGet();
-                } else {
-                    lastData.set(result.getResponse());
-                }
+                lastData.set(result.getResponse());
+                callbackCalled.countDown();
+            }, failure -> {
+                unexpectedCount.incrementAndGet();
                 callbackCalled.countDown();
             });
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
@@ -536,11 +538,10 @@ public class SmokeTest extends IntegrationTestSupport {
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.submitOneTimeWrite(new ModbusWriteCoilRequestBlueprint(SLAVE_UNIT_ID, 300, bits, false, 1),
                     result -> {
-                        if (result.hasError()) {
-                            lastError.set(result.getCause());
-                        } else {
-                            unexpectedCount.incrementAndGet();
-                        }
+                        unexpectedCount.incrementAndGet();
+                        callbackCalled.countDown();
+                    }, failure -> {
+                        lastError.set(failure.getCause());
                         callbackCalled.countDown();
                     });
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
@@ -577,9 +578,9 @@ public class SmokeTest extends IntegrationTestSupport {
             comms.registerRegularPoll(
                     new ModbusReadRequestBlueprint(SLAVE_UNIT_ID, ModbusReadFunctionCode.READ_COILS, 1, 15, 1), 150, 0,
                     result -> {
-                        if (result.getBits() != null) {
+                        BitArray bits = result.getBits();
+                        if (bits != null) {
                             dataReceived.incrementAndGet();
-                            BitArray bits = result.getBits();
                             try {
                                 assertThat(bits.size(), is(equalTo(15)));
                                 testCoilValues(bits, 1);
@@ -590,6 +591,9 @@ public class SmokeTest extends IntegrationTestSupport {
                         } else {
                             unexpectedCount.incrementAndGet();
                         }
+                        callbackCalled.countDown();
+                    }, failure -> {
+                        unexpectedCount.incrementAndGet();
                         callbackCalled.countDown();
                     });
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
@@ -619,19 +623,21 @@ public class SmokeTest extends IntegrationTestSupport {
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.registerRegularPoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 1, 15, 1), 150, 0, result -> {
-                        if (result.getRegisters() != null) {
+                        ModbusRegisterArray registers = result.getRegisters();
+                        if (registers != null) {
                             dataReceived.incrementAndGet();
-                            ModbusRegisterArray registers = result.getRegisters();
                             try {
                                 assertThat(registers.size(), is(equalTo(15)));
                                 testHoldingValues(registers, 1);
                             } catch (AssertionError e) {
                                 unexpectedCount.incrementAndGet();
                             }
-
                         } else {
                             unexpectedCount.incrementAndGet();
                         }
+                        callbackCalled.countDown();
+                    }, failure -> {
+                        unexpectedCount.incrementAndGet();
                         callbackCalled.countDown();
                     });
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
@@ -651,11 +657,11 @@ public class SmokeTest extends IntegrationTestSupport {
 
         long start = System.currentTimeMillis();
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
-            PollTask task = comms.registerRegularPoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
+            comms.registerRegularPoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 1, 15, 1), 150, 0, result -> {
-                        if (result.getRegisters() != null) {
+                        ModbusRegisterArray registers = result.getRegisters();
+                        if (registers != null) {
                             dataReceived.incrementAndGet();
-                            ModbusRegisterArray registers = result.getRegisters();
                             try {
                                 assertThat(registers.size(), is(equalTo(15)));
                                 testHoldingValues(registers, 1);
@@ -666,6 +672,9 @@ public class SmokeTest extends IntegrationTestSupport {
                         } else {
                             unexpectedCount.incrementAndGet();
                         }
+                        callbackCalled.countDown();
+                    }, failure -> {
+                        unexpectedCount.incrementAndGet();
                         callbackCalled.countDown();
                     });
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
@@ -711,24 +720,24 @@ public class SmokeTest extends IntegrationTestSupport {
 
         long start = System.currentTimeMillis();
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
-            PollTask task = comms.registerRegularPoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
+            comms.registerRegularPoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 1, 15, 1), 200, 0, result -> {
                         if (result.getRegisters() != null) {
                             expectedReceived.incrementAndGet();
                             successfulCountDownLatch.countDown();
-                        } else if (result.hasError()) {
-                            if (spi.getDigitalInCount() > 0) {
-                                // No errors expected after server filled with data
-                                unexpectedCount.incrementAndGet();
-                            } else {
-                                expectedReceived.incrementAndGet();
-                                errorCount.incrementAndGet();
-                                generateData();
-                                successfulCountDownLatch.countDown();
-                            }
                         } else {
                             // bits
                             unexpectedCount.incrementAndGet();
+                        }
+                    }, failure -> {
+                        if (spi.getDigitalInCount() > 0) {
+                            // No errors expected after server filled with data
+                            unexpectedCount.incrementAndGet();
+                        } else {
+                            expectedReceived.incrementAndGet();
+                            errorCount.incrementAndGet();
+                            generateData();
+                            successfulCountDownLatch.countDown();
                         }
                     });
             // Wait for N successful responses before proceeding with assertions of poll rate
@@ -758,20 +767,20 @@ public class SmokeTest extends IntegrationTestSupport {
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 1, 15, 1), 200, 0, result -> {
                         if (result.getRegisters() != null) {
                             expectedReceived.incrementAndGet();
-                        } else if (result.hasError()) {
-                            if (spi.getDigitalInCount() > 0) {
-                                // No errors expected after server filled with data
-                                unexpectedCount.incrementAndGet();
-                            } else {
-                                expectedReceived.incrementAndGet();
-                                errorCount.incrementAndGet();
-                                generateData();
-                            }
                         } else {
                             // bits
                             unexpectedCount.incrementAndGet();
                         }
                         callbackCalled.countDown();
+                    }, failure -> {
+                        if (spi.getDigitalInCount() > 0) {
+                            // No errors expected after server filled with data
+                            unexpectedCount.incrementAndGet();
+                        } else {
+                            expectedReceived.incrementAndGet();
+                            errorCount.incrementAndGet();
+                            generateData();
+                        }
                     });
             assertTrue(callbackCalled.await(60, TimeUnit.SECONDS));
             long end = System.currentTimeMillis();
@@ -834,6 +843,8 @@ public class SmokeTest extends IntegrationTestSupport {
                 comms.submitOneTimePoll(new ModbusReadRequestBlueprint(1, ModbusReadFunctionCode.READ_COILS, 0, 1, 1),
                         response -> {
                             latch.countDown();
+                        }, failure -> {
+                            latch.countDown();
                         });
                 assertTrue(latch.await(60, TimeUnit.SECONDS));
             }
@@ -848,6 +859,8 @@ public class SmokeTest extends IntegrationTestSupport {
                     CountDownLatch latch = new CountDownLatch(1);
                     comms.submitOneTimePoll(
                             new ModbusReadRequestBlueprint(1, ModbusReadFunctionCode.READ_COILS, 0, 1, 1), response -> {
+                                latch.countDown();
+                            }, failure -> {
                                 latch.countDown();
                             });
                     assertTrue(latch.await(60, TimeUnit.SECONDS));
@@ -894,6 +907,8 @@ public class SmokeTest extends IntegrationTestSupport {
                 CountDownLatch latch = new CountDownLatch(1);
                 comms.submitOneTimePoll(new ModbusReadRequestBlueprint(1, ModbusReadFunctionCode.READ_COILS, 0, 1, 1),
                         response -> {
+                            latch.countDown();
+                        }, failure -> {
                             latch.countDown();
                         });
                 assertTrue(latch.await(60, TimeUnit.SECONDS));

--- a/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/SmokeTest.java
+++ b/bundles/org.openhab.io.transport.modbus/src/test/java/org/openhab/io/transport/modbus/test/SmokeTest.java
@@ -25,6 +25,7 @@ import java.net.SocketImpl;
 import java.net.SocketImplFactory;
 import java.net.UnknownHostException;
 import java.util.BitSet;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
@@ -33,6 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.openhab.io.transport.modbus.BitArray;
@@ -150,7 +152,7 @@ public class SmokeTest extends IntegrationTestSupport {
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.submitOneTimePoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 0, 5, 1), result -> {
-                        assert result.getRegisters() != null;
+                        assert result.getRegisters().isPresent();
                         okCount.incrementAndGet();
                         callbackCalled.countDown();
                     }, failure -> {
@@ -187,7 +189,7 @@ public class SmokeTest extends IntegrationTestSupport {
                 configuration)) {
             comms.submitOneTimePoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 0, 5, 1), result -> {
-                        assert result.getRegisters() != null;
+                        assert result.getRegisters().isPresent();
                         okCount.incrementAndGet();
                         callbackCalled.countDown();
                     }, failure -> {
@@ -221,7 +223,7 @@ public class SmokeTest extends IntegrationTestSupport {
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.submitOneTimePoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 0, 5, 1), result -> {
-                        assert result.getRegisters() != null;
+                        assert result.getRegisters().isPresent();
                         okCount.incrementAndGet();
                         callbackCalled.countDown();
                     }, failure -> {
@@ -251,8 +253,9 @@ public class SmokeTest extends IntegrationTestSupport {
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.submitOneTimePoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID, functionCode, offset, count, 1),
                     result -> {
-                        if (result.getBits() != null) {
-                            lastData.set(result.getBits());
+                        Optional<@NonNull BitArray> bitsOptional = result.getBits();
+                        if (bitsOptional.isPresent()) {
+                            lastData.set(bitsOptional.get());
                         } else {
                             unexpectedCount.incrementAndGet();
                         }
@@ -349,9 +352,9 @@ public class SmokeTest extends IntegrationTestSupport {
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.submitOneTimePoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 1, 15, 1), result -> {
-                        if (result.getRegisters() != null) {
-                            assert result.getRegisters() != null;
-                            lastData.set(result.getRegisters());
+                        Optional<@NonNull ModbusRegisterArray> registersOptional = result.getRegisters();
+                        if (registersOptional.isPresent()) {
+                            lastData.set(registersOptional.get());
                         } else {
                             unexpectedCount.incrementAndGet();
                         }
@@ -384,9 +387,9 @@ public class SmokeTest extends IntegrationTestSupport {
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.submitOneTimePoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_INPUT_REGISTERS, 1, 15, 1), result -> {
-                        if (result.getRegisters() != null) {
-                            assert result.getRegisters() != null;
-                            lastData.set(result.getRegisters());
+                        Optional<@NonNull ModbusRegisterArray> registersOptional = result.getRegisters();
+                        if (registersOptional.isPresent()) {
+                            lastData.set(registersOptional.get());
                         } else {
                             unexpectedCount.incrementAndGet();
                         }
@@ -578,8 +581,9 @@ public class SmokeTest extends IntegrationTestSupport {
             comms.registerRegularPoll(
                     new ModbusReadRequestBlueprint(SLAVE_UNIT_ID, ModbusReadFunctionCode.READ_COILS, 1, 15, 1), 150, 0,
                     result -> {
-                        BitArray bits = result.getBits();
-                        if (bits != null) {
+                        Optional<@NonNull BitArray> bitsOptional = result.getBits();
+                        if (bitsOptional.isPresent()) {
+                            BitArray bits = bitsOptional.get();
                             dataReceived.incrementAndGet();
                             try {
                                 assertThat(bits.size(), is(equalTo(15)));
@@ -587,7 +591,6 @@ public class SmokeTest extends IntegrationTestSupport {
                             } catch (AssertionError e) {
                                 unexpectedCount.incrementAndGet();
                             }
-
                         } else {
                             unexpectedCount.incrementAndGet();
                         }
@@ -601,6 +604,7 @@ public class SmokeTest extends IntegrationTestSupport {
             long end = System.currentTimeMillis();
             assertPollDetails(unexpectedCount, dataReceived, start, end, 145, 500);
         }
+
     }
 
     /**
@@ -623,8 +627,9 @@ public class SmokeTest extends IntegrationTestSupport {
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.registerRegularPoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 1, 15, 1), 150, 0, result -> {
-                        ModbusRegisterArray registers = result.getRegisters();
-                        if (registers != null) {
+                        Optional<@NonNull ModbusRegisterArray> registersOptional = result.getRegisters();
+                        if (registersOptional.isPresent()) {
+                            ModbusRegisterArray registers = registersOptional.get();
                             dataReceived.incrementAndGet();
                             try {
                                 assertThat(registers.size(), is(equalTo(15)));
@@ -659,8 +664,9 @@ public class SmokeTest extends IntegrationTestSupport {
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.registerRegularPoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 1, 15, 1), 150, 0, result -> {
-                        ModbusRegisterArray registers = result.getRegisters();
-                        if (registers != null) {
+                        Optional<@NonNull ModbusRegisterArray> registersOptional = result.getRegisters();
+                        if (registersOptional.isPresent()) {
+                            ModbusRegisterArray registers = registersOptional.get();
                             dataReceived.incrementAndGet();
                             try {
                                 assertThat(registers.size(), is(equalTo(15)));
@@ -722,7 +728,8 @@ public class SmokeTest extends IntegrationTestSupport {
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             comms.registerRegularPoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 1, 15, 1), 200, 0, result -> {
-                        if (result.getRegisters() != null) {
+                        Optional<@NonNull ModbusRegisterArray> registersOptional = result.getRegisters();
+                        if (registersOptional.isPresent()) {
                             expectedReceived.incrementAndGet();
                             successfulCountDownLatch.countDown();
                         } else {
@@ -765,7 +772,8 @@ public class SmokeTest extends IntegrationTestSupport {
         try (ModbusCommunicationInterface comms = modbusManager.newModbusCommunicationInterface(endpoint, null)) {
             PollTask task = comms.registerRegularPoll(new ModbusReadRequestBlueprint(SLAVE_UNIT_ID,
                     ModbusReadFunctionCode.READ_MULTIPLE_REGISTERS, 1, 15, 1), 200, 0, result -> {
-                        if (result.getRegisters() != null) {
+                        Optional<@NonNull ModbusRegisterArray> registersOptional = result.getRegisters();
+                        if (registersOptional.isPresent()) {
                             expectedReceived.incrementAndGet();
                         } else {
                             // bits

--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusDataHandlerTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusDataHandlerTest.java
@@ -424,12 +424,12 @@ public class ModbusDataHandlerTest extends AbstractModbusOSGiTest {
             assertNull(registers);
             assertNull(error);
             AsyncModbusReadResult result = new AsyncModbusReadResult(request, bits);
-            dataHandler.handle(result);
+            dataHandler.onReadResult(result);
         } else if (registers != null) {
             assertNull(bits);
             assertNull(error);
             AsyncModbusReadResult result = new AsyncModbusReadResult(request, registers);
-            dataHandler.handle(result);
+            dataHandler.onReadResult(result);
         } else {
             assertNull(bits);
             assertNull(registers);

--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusDataHandlerTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusDataHandlerTest.java
@@ -14,8 +14,8 @@ package org.openhab.binding.modbus.tests;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.*;
 import static org.openhab.binding.modbus.internal.ModbusBindingConstantsInternal.*;
 
@@ -778,7 +778,7 @@ public class ModbusDataHandlerTest extends AbstractModbusOSGiTest {
                 builder -> builder.withConfiguration(dataConfig), bundleContext);
         assertThat(dataHandler.getThing().getStatus(), is(equalTo(ThingStatus.ONLINE)));
 
-        verify(comms, never()).submitOneTimePoll(request, notNull(), notNull());
+        verify(comms, never()).submitOneTimePoll(eq(request), notNull(), notNull());
         // Reset initial REFRESH commands to data thing channels from the Core
         reset(poller.getHandler());
         dataHandler.handleCommand(Mockito.mock(ChannelUID.class), RefreshType.REFRESH);

--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusDataHandlerTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusDataHandlerTest.java
@@ -448,7 +448,7 @@ public class ModbusDataHandlerTest extends AbstractModbusOSGiTest {
         ModbusSlaveEndpoint endpoint = new ModbusTCPSlaveEndpoint("thisishost", 502);
 
         // Minimally mocked request
-        ModbusWriteRequestBlueprint request = Mockito.mock(ModbusWriteRequestBlueprint.class);
+        ModbusReadRequestBlueprint request = Mockito.mock(ModbusReadRequestBlueprint.class);
 
         PollTask task = Mockito.mock(PollTask.class);
         doReturn(endpoint).when(task).getEndpoint();
@@ -473,7 +473,7 @@ public class ModbusDataHandlerTest extends AbstractModbusOSGiTest {
         dataHandler.handleCommand(new ChannelUID(dataHandler.getThing().getUID(), channel), command);
 
         if (error != null) {
-            dataHandler.handleWriteError(new AsyncModbusFailure<ModbusWriteRequestBlueprint>(request, error));
+            dataHandler.handleReadError(new AsyncModbusFailure<ModbusReadRequestBlueprint>(request, error));
         } else {
             ModbusResponse resp = new ModbusResponse() {
 
@@ -482,7 +482,8 @@ public class ModbusDataHandlerTest extends AbstractModbusOSGiTest {
                     return successFC.getFunctionCode();
                 }
             };
-            dataHandler.handle(new AsyncModbusWriteResult(Mockito.mock(ModbusWriteRequestBlueprint.class), resp));
+            dataHandler
+                    .onWriteResponse(new AsyncModbusWriteResult(Mockito.mock(ModbusWriteRequestBlueprint.class), resp));
         }
         return dataHandler;
     }

--- a/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusPollerThingHandlerTest.java
+++ b/itests/org.openhab.binding.modbus.tests/src/main/java/org/openhab/binding/modbus/tests/ModbusPollerThingHandlerTest.java
@@ -379,7 +379,7 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
         // has one data child
         thingHandler.childHandlerInitialized(child1, Mockito.mock(Thing.class));
         readCallback.handle(result);
-        verify(child1).handle(result);
+        verify(child1).onReadResult(result);
         verifyNoMoreInteractions(child1);
         verifyNoMoreInteractions(child2);
 
@@ -388,8 +388,8 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
         // two children (one child initialized)
         thingHandler.childHandlerInitialized(child2, Mockito.mock(Thing.class));
         readCallback.handle(result);
-        verify(child1).handle(result);
-        verify(child2).handle(result);
+        verify(child1).onReadResult(result);
+        verify(child2).onReadResult(result);
         verifyNoMoreInteractions(child1);
         verifyNoMoreInteractions(child2);
 
@@ -399,7 +399,7 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
         // one child disposed
         thingHandler.childHandlerDisposed(child1, Mockito.mock(Thing.class));
         readCallback.handle(result);
-        verify(child2).handle(result);
+        verify(child2).onReadResult(result);
         verifyNoMoreInteractions(child1);
         verifyNoMoreInteractions(child2);
     }
@@ -442,7 +442,7 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
         // has one data child
         thingHandler.childHandlerInitialized(child1, Mockito.mock(Thing.class));
         readCallback.handle(result);
-        verify(child1).handle(result);
+        verify(child1).onReadResult(result);
         verifyNoMoreInteractions(child1);
         verifyNoMoreInteractions(child2);
 
@@ -451,8 +451,8 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
         // two children (one child initialized)
         thingHandler.childHandlerInitialized(child2, Mockito.mock(Thing.class));
         readCallback.handle(result);
-        verify(child1).handle(result);
-        verify(child2).handle(result);
+        verify(child1).onReadResult(result);
+        verify(child2).onReadResult(result);
         verifyNoMoreInteractions(child1);
         verifyNoMoreInteractions(child2);
 
@@ -462,7 +462,7 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
         // one child disposed
         thingHandler.childHandlerDisposed(child1, Mockito.mock(Thing.class));
         readCallback.handle(result);
-        verify(child2).handle(result);
+        verify(child2).onReadResult(result);
         verifyNoMoreInteractions(child1);
         verifyNoMoreInteractions(child2);
     }
@@ -593,7 +593,7 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
         pollerReadCallback.handle(result);
 
         // data child receives the data
-        verify(child1).handle(result);
+        verify(child1).onReadResult(result);
         verifyNoMoreInteractions(child1);
         reset(child1);
 
@@ -603,7 +603,7 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
         verify(comms, never()).submitOneTimePoll(any(), any(), any());
 
         // data child receives the cached data
-        verify(child1).handle(result);
+        verify(child1).onReadResult(result);
         verifyNoMoreInteractions(child1);
     }
 
@@ -647,7 +647,7 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
         pollerReadCallback.handle(result);
 
         // data child receives the data
-        verify(child1).handle(result);
+        verify(child1).onReadResult(result);
         verifyNoMoreInteractions(child1);
         reset(child1);
 
@@ -707,7 +707,7 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
         pollerReadCallback.handle(registersResult);
 
         // data child should receive the data
-        verify(child1).handle(registersResult);
+        verify(child1).onReadResult(registersResult);
         verifyNoMoreInteractions(child1);
         reset(child1);
 
@@ -765,7 +765,7 @@ public class ModbusPollerThingHandlerTest extends AbstractModbusOSGiTest {
         pollerReadCallback.handle(result);
 
         // data child should receive the data
-        verify(child1).handle(result);
+        verify(child1).onReadResult(result);
         verifyNoMoreInteractions(child1);
         reset(child1);
 


### PR DESCRIPTION
Hello,

sorry for the delay, I was pretty much offline at the weekend. I've tested your code, and also read through the PR. I liked the proposal by @fwolter, mostly because it will allow to change most of the callback methods and parameters to be @NonNull.

However I understood that you were hesitating to start the refactor again, so I just started to look into the code to see how much would break... and after a while I showed to be long but relatively self understand set of changes.

So here in this PR you'll see how I accomplished those changes.

However there are a few things left I was considering also:

 - I've found out that ModbusDataThingHandler in org.openhab.binding.modbus has a lot of references to ModbusReadRequests, however a read task is never executed. I could not decide if it's an error caused by some refactor, or just some leftover dead code. I've added TODO's to the places I believe are never used now.

 - I've changed the result callback for ModbusCommunicationInterface::registerRegularPoll and ModbusCommunicationInterface::submitOneTimePoll to @NonNull. However I would like to go a step further and change every parameter @NonNull. This would make several internal classes to be nonnull  as well, and I don't really see a need to call those methods with a null callback. If it's really needed by some use case we could still override them with fewer parameters and internally pass along a VoidCallback. What do you think about this?
